### PR TITLE
Set default locale to en_us

### DIFF
--- a/cachewarmer/services/CacheWarmerService.php
+++ b/cachewarmer/services/CacheWarmerService.php
@@ -31,7 +31,7 @@ class CacheWarmerService extends BaseApplicationComponent
 
         // Get elements
         $criteria = craft()->elements->getCriteria(ElementType::Entry);
-        $criteria->setLanguage('en');
+        $criteria->setLanguage('en_us');
         $criteria->section = $sectionHandles;
 
         // Get entries count


### PR DESCRIPTION
Perhaps this changed at some point, but my default English locale in Craft is U.S. English: `en_us`.
